### PR TITLE
Migrate from 'static-only methods' to 'use Classes'

### DIFF
--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -205,7 +205,7 @@ public class RightClickHarvest {
         }
 
         private InteractionResult completeHarvest(BlockPos pos) {
-            if (level.isClientSide) return playSoundClientSide(state, player);
+            if (level.isClientSide) return playSoundClientSide();
 
             // ==== Server Side only below ====
 
@@ -228,7 +228,11 @@ public class RightClickHarvest {
             return InteractionResult.SUCCESS;
         }
 
-        // playSoundClientSide(state, player)
+        private InteractionResult playSoundClientSide() {
+            var soundEvent = block instanceof NetherWartBlock ? SoundEvents.NETHER_WART_PLANTED : SoundEvents.CROP_PLANTED;
+            player.playSound(soundEvent, 1.0f, 1.0f);
+            return InteractionResult.SUCCESS;
+        }
 
         // getReplantState(state)
 

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -227,7 +227,7 @@ public class RightClickHarvest {
             if (isReplantableAndMature()) level.setBlockAndUpdate(pos, getReplantState());
             else if (isSugarCaneOrCactus()) level.removeBlock(pos, false);
 
-            wearHoeInHand(player);
+            wearHoeInHand();
 
             // Regular block breaking causes 0.005f exhaustion
             player.causeFoodExhaustion(0.008f * CONFIG.get().hungerLevel.modifier);
@@ -243,7 +243,9 @@ public class RightClickHarvest {
             return InteractionResult.SUCCESS;
         }
 
-        // wearHoeInHand(player)
+        private void wearHoeInHand() {
+            if (isHoeInHand()) stackInMainHand.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
+        }
 
         // dropStacks(state, player, pos) // keep the pos arg
 

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -79,24 +79,9 @@ public class RightClickHarvest {
         return new Harvester(player, hitResult).harvest();
     }
 
-    static class Harvester {
-        private final Player player;
-        private final BlockHitResult hitResult;
-        private final Level level;
-        private final ItemStack stackInMainHand;
-        private final BlockState state;
-        private final BlockPos hitBlockPos;
-        private final Block block;
-
+    static class Harvester extends BaseHarvester {
         public Harvester(Player player, BlockHitResult hitResult) {
-            this.player = player;
-            this.hitResult = hitResult;
-
-            this.level = player.level();
-            this.stackInMainHand = player.getMainHandItem();
-            this.hitBlockPos = hitResult.getBlockPos();
-            this.state = level.getBlockState(hitBlockPos);
-            this.block = state.getBlock();
+            super(player, hitResult);
         }
 
         public InteractionResult harvest() {
@@ -108,8 +93,35 @@ public class RightClickHarvest {
 
             return maybeBlockHarvest();
         }
+    }
 
-        private boolean isHoeRequiredWithWarning() {
+    static class RadiusHarvester extends BaseHarvester {
+        public RadiusHarvester(Player player, BlockHitResult hitResult) {
+            super(player, hitResult);
+        }
+    }
+
+    static class BaseHarvester {
+        private final Player player;
+        private final BlockHitResult hitResult;
+        private final Level level;
+        private final ItemStack stackInMainHand;
+        private final BlockState state;
+        private final BlockPos hitBlockPos;
+        private final Block block;
+
+        public BaseHarvester(Player player, BlockHitResult hitResult) {
+            this.player = player;
+            this.hitResult = hitResult;
+
+            this.level = player.level();
+            this.stackInMainHand = player.getMainHandItem();
+            this.hitBlockPos = hitResult.getBlockPos();
+            this.state = level.getBlockState(hitBlockPos);
+            this.block = state.getBlock();
+        }
+
+         protected boolean isHoeRequiredWithWarning() {
             // Check if the block requires a hoe; if so, check if a hoe is required and if the user has one.
             var required = !state.is(HOE_NEVER_REQUIRED) && CONFIG.get().requireHoe && !isHoeInHand() && isHarvestable();
             if (required) warnOnceForNotUsingHoe();
@@ -168,7 +180,7 @@ public class RightClickHarvest {
             };
         }
 
-        private boolean cannotHarvest() {
+        protected boolean cannotHarvest() {
             return state.is(BLACKLIST) || isExhausted();
         }
 
@@ -179,7 +191,7 @@ public class RightClickHarvest {
             return player.getFoodData().getFoodLevel() <= 0;
         }
 
-        private InteractionResult maybeBlockHarvest() {
+        protected InteractionResult maybeBlockHarvest() {
             if (isReplantableAndMature()) return completeHarvest();
             if (isSugarCaneOrCactus()) return harvestSugarCaneOrCactus();
 
@@ -263,11 +275,11 @@ public class RightClickHarvest {
             }
         }
 
-        private boolean canRadiusHarvest() {
+        protected boolean canRadiusHarvest() {
             return CONFIG.get().harvestInRadius && !state.is(RADIUS_HARVEST_BLACKLIST) && isHoeInHand() && isReplantableAndMature();
         }
 
-        private void attemptRadiusHarvesting() {
+        protected void attemptRadiusHarvesting() {
             int radius = 0;
             boolean circle = false;
 
@@ -307,6 +319,7 @@ public class RightClickHarvest {
 
         // maybeRadiusHarvest(player, hitResult.withPosition(pos))
     }
+
 
     private static BlockState getBlockState(Player player, BlockHitResult hitResult) {
         Level level = player.level();

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -85,6 +85,7 @@ public class RightClickHarvest {
         private final Level level;
         private final ItemStack mainHandItem;
         private final BlockState state;
+        private final Block block;
 
         public Harvester(Player player, BlockHitResult hitResult) {
             this.player = player;
@@ -93,6 +94,7 @@ public class RightClickHarvest {
             this.level = player.level();
             this.mainHandItem = player.getMainHandItem();
             this.state = level.getBlockState(hitResult.getBlockPos());
+            this.block = state.getBlock();
         }
 
         public InteractionResult harvest() {
@@ -135,8 +137,27 @@ public class RightClickHarvest {
         }
 
         private boolean isHarvestable() {
-            return isReplantableAndMature(state) || isSugarCaneOrCactus(state);
+            return isReplantableAndMature() || isSugarCaneOrCactus(state);
         }
+
+        private boolean isReplantableAndMature() {
+            return isReplantable() && isMature();
+        }
+
+        private boolean isReplantable() {
+            return block instanceof CocoaBlock || block instanceof CropBlock || block instanceof NetherWartBlock;
+        }
+
+        private boolean isMature() {
+            return switch (block) {
+                case CocoaBlock cocoaBlock -> state.getValue(CocoaBlock.AGE) >= CocoaBlock.MAX_AGE;
+                case CropBlock cropBlock -> cropBlock.isMaxAge(state);
+                case NetherWartBlock netherWartBlock -> state.getValue(NetherWartBlock.AGE) >= NetherWartBlock.MAX_AGE;
+                default -> false;
+            };
+        }
+
+        // isSugarCaneOrCactus(state)
     }
 
     private static BlockState getBlockState(Player player, BlockHitResult hitResult) {

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -79,11 +79,6 @@ public class RightClickHarvest {
         return new Harvester(player, hitResult).harvest();
     }
 
-    private static BlockState getBlockState(Player player, BlockHitResult hitResult) {
-        Level level = player.level();
-        return level.getBlockState(hitResult.getBlockPos());
-    }
-
     private static boolean cannotRadiusHarvest(Player player, BlockState state) {
         return state.is(RADIUS_HARVEST_BLACKLIST) && cannotHarvest(player, state);
     }
@@ -92,145 +87,11 @@ public class RightClickHarvest {
         return state.is(BLACKLIST) || isExhausted(player);
     }
 
-    private static InteractionResult blockHarvest(Player player, BlockHitResult hitResult, BlockState state) {
-        if (isReplantableAndMature(state)) return completeHarvest(state, player, hitResult.getBlockPos());
-        if (isSugarCaneOrCactus(state)) return harvestSugarCaneOrCactus(player, hitResult, state);
-
-        return InteractionResult.PASS;
-    }
-
-    private static InteractionResult harvestSugarCaneOrCactus(Player player, BlockHitResult hitResult, BlockState state) {
-        ItemStack stackInHand = player.getMainHandItem();
-        if (hitResult.getDirection() == Direction.UP && ((stackInHand.getItem() == Items.SUGAR_CANE && state.getBlock() instanceof SugarCaneBlock) || (stackInHand.getItem() == Items.CACTUS && state.getBlock() instanceof CactusBlock))) {
-            return InteractionResult.PASS;
-        }
-
-        Block lookingFor = state.getBlock() instanceof SugarCaneBlock ? Blocks.SUGAR_CANE : Blocks.CACTUS;
-        BlockPos bottom = hitResult.getBlockPos();
-        Level level = player.level();
-        while (level.getBlockState(bottom.below()).is(lookingFor)) {
-            bottom = bottom.below();
-        }
-
-        // Only one block tall
-        if (!level.getBlockState(bottom.above()).is(lookingFor)) {
-            return InteractionResult.PASS;
-        }
-
-        final BlockPos breakPos = bottom.above(1);
-        return completeHarvest(state, player, breakPos);
-    }
-
-    private static InteractionResult completeHarvest(BlockState state, Player player, BlockPos pos) {
-        Level level = player.level();
-
-        if (level.isClientSide) return playSoundClientSide(state, player);
-
-        // ==== Server Side only below ====
-
-        // Event posts are for things like claim mods
-        if (RightClickHarvestPlatform.postBreakEvent(pos, state, player)) return InteractionResult.FAIL;
-        if (RightClickHarvestPlatform.postPlaceEvent(pos, player)) return InteractionResult.FAIL;
-
-        dropStacks(state, player, pos);
-
-        Block originalBlock = state.getBlock();
-
-        if (isReplantableAndMature(state)) {
-            level.setBlockAndUpdate(pos, getReplantState(state));
-        } else if (isSugarCaneOrCactus(state)) {
-            level.removeBlock(pos, false);
-        }
-
-        wearHoeInHand(player);
-
-        // Regular block breaking causes 0.005f exhaustion
-        player.causeFoodExhaustion(0.008f * CONFIG.get().hungerLevel.modifier);
-
-        RightClickHarvestPlatform.postAfterHarvestEvent(player, originalBlock);
-
-        return InteractionResult.SUCCESS;
-    }
-
-    private static InteractionResult playSoundClientSide(BlockState state, Player player) {
-        player.playSound(getSoundEvent(state), 1.0f, 1.0f);
-        return InteractionResult.SUCCESS;
-    }
-
-    private static SoundEvent getSoundEvent(BlockState state) {
-        return state.getBlock() instanceof NetherWartBlock ? SoundEvents.NETHER_WART_PLANTED : SoundEvents.CROP_PLANTED;
-    }
-
     // Check for hunger, if config requires it
     private static boolean isExhausted(Player player) {
         if (player.hasInfiniteMaterials()) return false;
         if (CONFIG.get().hungerLevel != Config.HungerLevel.NONE) return false;
         return player.getFoodData().getFoodLevel() <= 0;
-    }
-
-    private static boolean isReplantable(BlockState state) {
-        return isReplantable(state.getBlock());
-    }
-
-    private static boolean isReplantable(Block block) {
-        return block instanceof CocoaBlock || block instanceof CropBlock || block instanceof NetherWartBlock;
-    }
-
-    private static boolean isSugarCaneOrCactus(BlockState state) {
-        Block block = state.getBlock();
-        return block instanceof SugarCaneBlock || block instanceof CactusBlock;
-    }
-
-    private static boolean isReplantableAndMature(BlockState state) {
-        Block block = state.getBlock();
-        return switch (block) {
-            case CocoaBlock cocoaBlock -> state.getValue(CocoaBlock.AGE) >= CocoaBlock.MAX_AGE;
-            case CropBlock cropBlock -> cropBlock.isMaxAge(state);
-            case NetherWartBlock netherWartBlock -> state.getValue(NetherWartBlock.AGE) >= NetherWartBlock.MAX_AGE;
-            default -> false;
-        };
-    }
-
-    private static void wearHoeInHand(Player player) {
-        ItemStack hoeInHand = player.getMainHandItem();
-        if (!isHoeInHand(player)) return;
-        hoeInHand.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
-    }
-
-    private static boolean isHoeInHand(Player player) {
-        ItemStack mainHandItem = player.getMainHandItem();
-        return mainHandItem.is(ItemTags.HOES)
-                || mainHandItem.is(LOW_TIER_HOES)
-                || mainHandItem.is(MID_TIER_HOES)
-                || mainHandItem.is(HIGH_TIER_HOES)
-                || RightClickHarvestPlatform.isHoeAccordingToPlatform(mainHandItem);
-    }
-
-    private static BlockState getReplantState(BlockState state) {
-        Block block = state.getBlock();
-        return switch (block) {
-            case CocoaBlock cocoaBlock -> state.setValue(CocoaBlock.AGE, 0);
-            case CropBlock cropBlock -> cropBlock.getStateForAge(0);
-            case NetherWartBlock netherWartBlock -> state.setValue(NetherWartBlock.AGE, 0);
-            default -> state;
-        };
-    }
-
-    private static void dropStacks(BlockState state, Player player, BlockPos pos) {
-        ServerLevel world = (ServerLevel) player.level();
-        List<ItemStack> drops = Block.getDrops(state, world, pos, null, player, player.getMainHandItem());
-        Block block = state.getBlock();
-        Item replant = block.asItem();
-        boolean needToReplant = isReplantable(block);
-
-        for (ItemStack droppedStack : drops) {
-            if (needToReplant && droppedStack.is(replant)) {
-                droppedStack.shrink(1);
-                needToReplant = false;
-            }
-
-            Block.popResource(world, pos, droppedStack);
-        }
     }
 
     private static ResourceLocation id(String path) {

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -83,6 +83,7 @@ public class RightClickHarvest {
         private final Player player;
         private final BlockHitResult hitResult;
         private final Level level;
+        private final ItemStack mainHandItem;
         private final BlockState state;
 
         public Harvester(Player player, BlockHitResult hitResult) {
@@ -90,6 +91,7 @@ public class RightClickHarvest {
             this.hitResult = hitResult;
 
             this.level = player.level();
+            this.mainHandItem = player.getMainHandItem();
             this.state = level.getBlockState(hitResult.getBlockPos());
         }
 
@@ -105,7 +107,7 @@ public class RightClickHarvest {
 
         private boolean isHoeRequiredWithWarning() {
             // Check if the block requires a hoe; if so, check if a hoe is required and if the user has one.
-            var isHoeRequired = !state.is(HOE_NEVER_REQUIRED) && CONFIG.get().requireHoe && !isHoeInHand(player);
+            var isHoeRequired = !state.is(HOE_NEVER_REQUIRED) && CONFIG.get().requireHoe && !isHoeInHand();
             if (isHoeRequired) warnOnceForNotUsingHoe();
             return isHoeRequired;
         }
@@ -124,7 +126,14 @@ public class RightClickHarvest {
             CONFIG.save();
         }
 
-        // isHoeInHand(player)
+        private boolean isHoeInHand() {
+            return mainHandItem.is(ItemTags.HOES)
+                    || mainHandItem.is(LOW_TIER_HOES)
+                    || mainHandItem.is(MID_TIER_HOES)
+                    || mainHandItem.is(HIGH_TIER_HOES)
+                    || RightClickHarvestPlatform.isHoeAccordingToPlatform(mainHandItem);
+        }
+
         // isHarvestable(state)
     }
 
@@ -298,20 +307,17 @@ public class RightClickHarvest {
 
     private static void wearHoeInHand(Player player) {
         ItemStack hoeInHand = player.getMainHandItem();
-        if (!isHoe(hoeInHand)) return;
+        if (!isHoeInHand(player)) return;
         hoeInHand.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
     }
 
     private static boolean isHoeInHand(Player player) {
-        return isHoe(player.getMainHandItem());
-    }
-
-    private static boolean isHoe(ItemStack stack) {
-        return stack.is(ItemTags.HOES)
-               || stack.is(LOW_TIER_HOES)
-               || stack.is(MID_TIER_HOES)
-               || stack.is(HIGH_TIER_HOES)
-               || RightClickHarvestPlatform.isHoeAccordingToPlatform(stack);
+        ItemStack mainHandItem = player.getMainHandItem();
+        return mainHandItem.is(ItemTags.HOES)
+               || mainHandItem.is(LOW_TIER_HOES)
+               || mainHandItem.is(MID_TIER_HOES)
+               || mainHandItem.is(HIGH_TIER_HOES)
+               || RightClickHarvestPlatform.isHoeAccordingToPlatform(mainHandItem);
     }
 
     private static BlockState getReplantState(BlockState state) {

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -195,7 +195,6 @@ public class RightClickHarvest {
             }
 
             var lookingFor = block;
-            var lookingFor = block;
             var bottom = hitBlockPos;
             while (level.getBlockState(bottom.below()).is(lookingFor)) {
                 bottom = bottom.below();

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -194,7 +194,8 @@ public class RightClickHarvest {
                 return InteractionResult.PASS;
             }
 
-            var lookingFor = block instanceof SugarCaneBlock ? Blocks.SUGAR_CANE : Blocks.CACTUS;
+            var lookingFor = block;
+            var lookingFor = block;
             var bottom = hitBlockPos;
             while (level.getBlockState(bottom.below()).is(lookingFor)) {
                 bottom = bottom.below();

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -107,13 +107,13 @@ public class RightClickHarvest {
 
         private boolean isHoeRequiredWithWarning() {
             // Check if the block requires a hoe; if so, check if a hoe is required and if the user has one.
-            var isHoeRequired = !state.is(HOE_NEVER_REQUIRED) && CONFIG.get().requireHoe && !isHoeInHand();
-            if (isHoeRequired) warnOnceForNotUsingHoe();
-            return isHoeRequired;
+            var required = !state.is(HOE_NEVER_REQUIRED) && CONFIG.get().requireHoe && !isHoeInHand() && isHarvestable();
+            if (required) warnOnceForNotUsingHoe();
+            return required;
         }
 
         private void warnOnceForNotUsingHoe() {
-            if (CONFIG.get().hasUserBeenWarnedForNotUsingHoe || !level.isClientSide || !isHarvestable(state)) return;
+            if (CONFIG.get().hasUserBeenWarnedForNotUsingHoe || !level.isClientSide) return;
 
             var translatable = Component.translatable(
                     "text.rightclickharvest.use_a_hoe_warning",
@@ -134,7 +134,9 @@ public class RightClickHarvest {
                     || RightClickHarvestPlatform.isHoeAccordingToPlatform(mainHandItem);
         }
 
-        // isHarvestable(state)
+        private boolean isHarvestable() {
+            return isReplantableAndMature(state) || isSugarCaneOrCactus(state);
+        }
     }
 
     private static BlockState getBlockState(Player player, BlockHitResult hitResult) {
@@ -285,10 +287,6 @@ public class RightClickHarvest {
     private static boolean isSugarCaneOrCactus(BlockState state) {
         Block block = state.getBlock();
         return block instanceof SugarCaneBlock || block instanceof CactusBlock;
-    }
-
-    private static boolean isHarvestable(BlockState state) {
-        return isReplantableAndMature(state) || isSugarCaneOrCactus(state);
     }
 
     private static boolean isReplantableAndMature(BlockState state) {

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -159,6 +159,15 @@ public class RightClickHarvest {
             };
         }
 
+        private BlockState getReplantState() {
+            return switch (block) {
+                case CocoaBlock cocoaBlock -> state.setValue(CocoaBlock.AGE, 0);
+                case CropBlock cropBlock -> cropBlock.getStateForAge(0);
+                case NetherWartBlock netherWartBlock -> state.setValue(NetherWartBlock.AGE, 0);
+                default -> state;
+            };
+        }
+
         private boolean cannotHarvest() {
             return state.is(BLACKLIST) || isExhausted();
         }
@@ -215,7 +224,7 @@ public class RightClickHarvest {
 
             dropStacks(state, player, pos);
 
-            if (isReplantableAndMature()) level.setBlockAndUpdate(pos, getReplantState(state));
+            if (isReplantableAndMature()) level.setBlockAndUpdate(pos, getReplantState());
             else if (isSugarCaneOrCactus()) level.removeBlock(pos, false);
 
             wearHoeInHand(player);
@@ -233,8 +242,6 @@ public class RightClickHarvest {
             player.playSound(soundEvent, 1.0f, 1.0f);
             return InteractionResult.SUCCESS;
         }
-
-        // getReplantState(state)
 
         // wearHoeInHand(player)
 

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -140,15 +140,11 @@ public class RightClickHarvest {
             return isReplantableAndMature() || isSugarCaneOrCactus(state);
         }
 
-        private boolean isReplantableAndMature() {
-            return isReplantable() && isMature();
-        }
-
         private boolean isReplantable() {
             return block instanceof CocoaBlock || block instanceof CropBlock || block instanceof NetherWartBlock;
         }
 
-        private boolean isMature() {
+        private boolean isReplantableAndMature() {
             return switch (block) {
                 case CocoaBlock cocoaBlock -> state.getValue(CocoaBlock.AGE) >= CocoaBlock.MAX_AGE;
                 case CropBlock cropBlock -> cropBlock.isMaxAge(state);
@@ -311,10 +307,6 @@ public class RightClickHarvest {
     }
 
     private static boolean isReplantableAndMature(BlockState state) {
-        return isReplantable(state) && isMature(state);
-    }
-
-    private static boolean isMature(BlockState state) {
         Block block = state.getBlock();
         return switch (block) {
             case CocoaBlock cocoaBlock -> state.getValue(CocoaBlock.AGE) >= CocoaBlock.MAX_AGE;

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -106,7 +106,7 @@ public class RightClickHarvest {
 
             if (canRadiusHarvest()) attemptRadiusHarvesting();
 
-            return maybeBlockHarvest(player, hitResult, state);
+            return maybeBlockHarvest();
         }
 
         private boolean isHoeRequiredWithWarning() {
@@ -170,7 +170,16 @@ public class RightClickHarvest {
             return player.getFoodData().getFoodLevel() <= 0;
         }
 
-        // maybeBlockHarvest(player, hitResult, state)
+        private InteractionResult maybeBlockHarvest() {
+            if (isReplantableAndMature()) return completeHarvest(state, player, hitBlockPos);
+            if (isSugarCaneOrCactus()) return harvestSugarCaneOrCactus(player, hitResult, state);
+
+            return InteractionResult.PASS;
+        }
+
+        // completeHarvest(state, player, hitBlockPos)
+
+        // harvestSugarCaneOrCactus(player, hitResult, state)
 
         private boolean canRadiusHarvest() {
             return CONFIG.get().harvestInRadius && !state.is(RADIUS_HARVEST_BLACKLIST) && isHoeInHand() && isReplantableAndMature();

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -92,12 +92,6 @@ public class RightClickHarvest {
         return state.is(BLACKLIST) || isExhausted(player);
     }
 
-    private static void maybeRadiusHarvest(Player player, BlockHitResult hitResult) {
-        BlockState state = getBlockState(player, hitResult);
-        if (cannotRadiusHarvest(player, state)) return;
-        blockHarvest(player, hitResult, state);
-    }
-
     private static InteractionResult blockHarvest(Player player, BlockHitResult hitResult, BlockState state) {
         if (isReplantableAndMature(state)) return completeHarvest(state, player, hitResult.getBlockPos());
         if (isSugarCaneOrCactus(state)) return harvestSugarCaneOrCactus(player, hitResult, state);
@@ -305,7 +299,7 @@ public class RightClickHarvest {
 
             if (radius == 1 && circle) {
                 for (Direction dir : CARDINAL_DIRECTIONS) {
-                    maybeRadiusHarvest(player, hitResult.withPosition(hitBlockPos.relative(dir)));
+                    new RadiusHarvester(player, hitResult.withPosition(hitBlockPos.relative(dir))).harvest();
                 }
             } else if (radius > 0) {
                 for (int x = -radius; x <= radius; x++) {
@@ -319,7 +313,7 @@ public class RightClickHarvest {
                             continue;
                         }
 
-                        maybeRadiusHarvest(player, hitResult.withPosition(pos));
+                        new RadiusHarvester(player, hitResult.withPosition(pos)).harvest();
                     }
                 }
             }
@@ -330,6 +324,13 @@ public class RightClickHarvest {
         public RadiusHarvester(Player player, BlockHitResult hitResult) {
             super(player, hitResult);
         }
+
+        public void harvest() {
+            if (cannotRadiusHarvest(player, state)) return;
+            blockHarvest();
+        }
+
+        // cannotRadiusHarvest(player, state)
     }
 
     static class BaseHarvester {

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -76,15 +76,32 @@ public class RightClickHarvest {
             return InteractionResult.PASS;
         }
 
-        BlockState state = getBlockState(player, hitResult);
+        return new Harvester(player, hitResult).harvest();
+    }
 
-        if (isHoeRequiredWithWarning(player, state)) return InteractionResult.PASS;
+    static class Harvester {
+        private final Player player;
+        private final BlockHitResult hitResult;
+        private final Level level;
+        private final BlockState state;
 
-        if (cannotHarvest(player, state)) return InteractionResult.PASS;
+        public Harvester(Player player, BlockHitResult hitResult) {
+            this.player = player;
+            this.hitResult = hitResult;
 
-        if (canRadiusHarvest(player, state)) attemptRadiusHarvesting(player, hitResult);
+            this.level = player.level();
+            this.state = level.getBlockState(hitResult.getBlockPos());
+        }
 
-        return maybeBlockHarvest(player, hitResult, state);
+        public InteractionResult harvest() {
+            if (isHoeRequiredWithWarning(player, state)) return InteractionResult.PASS;
+
+            if (cannotHarvest(player, state)) return InteractionResult.PASS;
+
+            if (canRadiusHarvest(player, state)) attemptRadiusHarvesting(player, hitResult);
+
+            return maybeBlockHarvest(player, hitResult, state);
+        }
     }
 
     private static BlockState getBlockState(Player player, BlockHitResult hitResult) {

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -12,7 +12,6 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
@@ -25,7 +24,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CactusBlock;
 import net.minecraft.world.level.block.CocoaBlock;
 import net.minecraft.world.level.block.CropBlock;
@@ -79,21 +77,6 @@ public class RightClickHarvest {
         return new Harvester(player, hitResult).harvest();
     }
 
-    private static boolean cannotRadiusHarvest(Player player, BlockState state) {
-        return state.is(RADIUS_HARVEST_BLACKLIST) && cannotHarvest(player, state);
-    }
-
-    private static boolean cannotHarvest(Player player, BlockState state) {
-        return state.is(BLACKLIST) || isExhausted(player);
-    }
-
-    // Check for hunger, if config requires it
-    private static boolean isExhausted(Player player) {
-        if (player.hasInfiniteMaterials()) return false;
-        if (CONFIG.get().hungerLevel != Config.HungerLevel.NONE) return false;
-        return player.getFoodData().getFoodLevel() <= 0;
-    }
-
     private static ResourceLocation id(String path) {
         return ResourceLocation.fromNamespaceAndPath(MOD_ID, path);
     }
@@ -108,7 +91,7 @@ public class RightClickHarvest {
 
             if (cannotHarvest()) return InteractionResult.PASS;
 
-            if (canRadiusHarvest()) attemptRadiusHarvesting();
+            if (canRadiusHarvest()) radiusHarvest();
 
             return blockHarvest();
         }
@@ -142,7 +125,7 @@ public class RightClickHarvest {
             return CONFIG.get().harvestInRadius && !state.is(RADIUS_HARVEST_BLACKLIST) && isHoeInHand() && isReplantableAndMature();
         }
 
-        private void attemptRadiusHarvesting() {
+        private void radiusHarvest() {
             int radius = 0;
             boolean circle = false;
 
@@ -187,11 +170,13 @@ public class RightClickHarvest {
         }
 
         public void harvest() {
-            if (cannotRadiusHarvest(player, state)) return;
+            if (cannotRadiusHarvest()) return;
             blockHarvest();
         }
 
-        // cannotRadiusHarvest(player, state)
+        private boolean cannotRadiusHarvest() {
+            return state.is(RADIUS_HARVEST_BLACKLIST) && cannotHarvest();
+        }
     }
 
     static class BaseHarvester {

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -137,11 +137,15 @@ public class RightClickHarvest {
         }
 
         private boolean isHarvestable() {
-            return isReplantableAndMature() || isSugarCaneOrCactus(state);
+            return isReplantableAndMature() || isSugarCaneOrCactus();
         }
 
         private boolean isReplantable() {
             return block instanceof CocoaBlock || block instanceof CropBlock || block instanceof NetherWartBlock;
+        }
+
+        private boolean isSugarCaneOrCactus() {
+            return block instanceof SugarCaneBlock || block instanceof CactusBlock;
         }
 
         private boolean isReplantableAndMature() {
@@ -152,8 +156,6 @@ public class RightClickHarvest {
                 default -> false;
             };
         }
-
-        // isSugarCaneOrCactus(state)
     }
 
     private static BlockState getBlockState(Player player, BlockHitResult hitResult) {

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -102,7 +102,7 @@ public class RightClickHarvest {
 
             if (cannotHarvest()) return InteractionResult.PASS;
 
-            if (canRadiusHarvest(player, state)) attemptRadiusHarvesting(player, hitResult);
+            if (canRadiusHarvest()) attemptRadiusHarvesting(player, hitResult);
 
             return maybeBlockHarvest(player, hitResult, state);
         }
@@ -168,7 +168,10 @@ public class RightClickHarvest {
             return player.getFoodData().getFoodLevel() <= 0;
         }
 
-        // canRadiusHarvest(player, state)
+        private boolean canRadiusHarvest() {
+            return CONFIG.get().harvestInRadius && !state.is(RADIUS_HARVEST_BLACKLIST) && isHoeInHand() && isReplantableAndMature();
+        }
+
         // attemptRadiusHarvesting(player, hitResult)
         // maybeBlockHarvest(player, hitResult, state)
     }
@@ -176,10 +179,6 @@ public class RightClickHarvest {
     private static BlockState getBlockState(Player player, BlockHitResult hitResult) {
         Level level = player.level();
         return level.getBlockState(hitResult.getBlockPos());
-    }
-
-    private static boolean canRadiusHarvest(Player player, BlockState state) {
-        return CONFIG.get().harvestInRadius && !state.is(RADIUS_HARVEST_BLACKLIST) && isHoeInHand(player) && isReplantableAndMature(state);
     }
 
     private static boolean cannotRadiusHarvest(Player player, BlockState state) {

--- a/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
+++ b/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java
@@ -100,7 +100,7 @@ public class RightClickHarvest {
         public InteractionResult harvest() {
             if (isHoeRequiredWithWarning()) return InteractionResult.PASS;
 
-            if (cannotHarvest(player, state)) return InteractionResult.PASS;
+            if (cannotHarvest()) return InteractionResult.PASS;
 
             if (canRadiusHarvest(player, state)) attemptRadiusHarvesting(player, hitResult);
 
@@ -156,6 +156,21 @@ public class RightClickHarvest {
                 default -> false;
             };
         }
+
+        private boolean cannotHarvest() {
+            return state.is(BLACKLIST) || isExhausted();
+        }
+
+        // Check for hunger, if config requires it
+        private boolean isExhausted() {
+            if (player.hasInfiniteMaterials()) return false;
+            if (CONFIG.get().hungerLevel != Config.HungerLevel.NONE) return false;
+            return player.getFoodData().getFoodLevel() <= 0;
+        }
+
+        // canRadiusHarvest(player, state)
+        // attemptRadiusHarvesting(player, hitResult)
+        // maybeBlockHarvest(player, hitResult, state)
     }
 
     private static BlockState getBlockState(Player player, BlockHitResult hitResult) {

--- a/fabric-gametest/src/main/java/io/github/jamalam360/rightclickharvest/gametest/TestHelper.java
+++ b/fabric-gametest/src/main/java/io/github/jamalam360/rightclickharvest/gametest/TestHelper.java
@@ -24,7 +24,7 @@ public class TestHelper {
         pos = helper.absolutePos(pos);
         player.setItemInHand(InteractionHand.MAIN_HAND, stack);
         BlockHitResult hitResult = new BlockHitResult(Vec3.atLowerCornerOf(pos), Direction.NORTH, pos, false);
-        RightClickHarvest.onBlockUse(player, InteractionHand.MAIN_HAND, hitResult);
+        RightClickHarvest.onBlockUse(player, hitResult);
     }
 
     public static void assertStateInRadius(GameTestHelper helper, BlockPos center, int radius, boolean circle, boolean includeCentre, Predicate<BlockState> predicate) {


### PR DESCRIPTION
Another attempt to arguably improve the readability and expandability :)

As a bonus, now the Sugar Cane that is right next to the re-plantable crops is also radius-harvested as the Cactus.

Also, it is easy to enable the radius-harvesting started on the Cactus and Sugar Cane blocks.
For that, change here
https://github.com/AlexKVal/right-click-harvest/blob/e5368637641767a1810fc0465e01b45ef4293482/common/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvest.java#L122-L123
the `isReplantableAndMature` -> `isHarvestable`